### PR TITLE
Use `justify-between` instead of `w-1/2`.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "illuminate/view": "^9.4",
         "laravel-zero/framework": "^9.0",
         "mockery/mockery": "^1.4.4",
-        "nunomaduro/termwind": "^1.3",
+        "nunomaduro/termwind": "^1.7",
         "pestphp/pest": "^1.21.1",
         "phpstan/phpstan": "^1.5",
         "soundasleep/html2text": "^2.0",

--- a/resources/views/stats.blade.php
+++ b/resources/views/stats.blade.php
@@ -1,11 +1,11 @@
 <div class="ml-2 my-1">
     <div class="w-full {{ $headerStyle }} max-w-100"></div>
-    <div class="w-full {{ $headerStyle }} px-2 max-w-100">
-        <span class="text-left w-1/2">
+    <div class="w-full {{ $headerStyle }} px-2 max-w-100 justify-between">
+        <span>
             <span class="uppercase font-bold mr-1">{{ $method }}</span>
             <span>{{ $url }}</span>
         </span>
-        <span class="text-right w-1/2">
+        <span>
             {{ $statusCode }}
         </span>
     </div>


### PR DESCRIPTION
With Termwind v1.7, instead of using w-1/2 and text alignment we can take advantage of the justify-between helper.

💪