### PR TITLE
check bat version while checking if bat is executable

### DIFF
--- a/app/Colorizers/HtmlColorizer.php
+++ b/app/Colorizers/HtmlColorizer.php
@@ -23,4 +23,15 @@ class HtmlColorizer extends Colorizer
 
         return $process->getOutput();
     }
+
+    protected function colorizerCanExecute(): bool
+    {
+        $process = Process::fromShellCommandline("{$this->getColorizerToolPath()} --version");
+
+        $process->run();
+
+        [, $version] = explode(' ', $process->getOutput());
+
+        return $process->isSuccessful() && $version >= 0.16;
+    }
 }


### PR DESCRIPTION
This PR adds a version check while checking if the current `bat` version is at least 0.16 [See this comment](https://github.com/spatie/visit/issues/9#issuecomment-1085887480)

Fixes #9 

We could add this check somewhere else, but this seemed more efficient as we don't need to create another `Symfony\Component\Process\Process`. Also, the function name `colorizerCanExecute` seems an okay place to hold this logic. 

I've successfully reproduced Issue #9 in both Mac & ubuntu and this fix works in both cases.